### PR TITLE
Remove RUSTFLAGS in make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ check:
 .PHONY: lint
 lint:
 	cargo fmt --check
-	RUSTLFAGS='-Dwarnings' cargo check --all-features --all-targets
+	cargo check --all-features --all-targets
 	cargo clippy --all-targets --all-features -- -Dwarnings
 	RUSTDOCFLAGS='-Dwarnings' cargo doc --all-features
 	reuse lint


### PR DESCRIPTION
Cargo recompiles everything when the RUSTFLAGS change so this makes lint slower than they need to be. Removing this doesn't miss any lints because the clippy pass also has `--deny warnings`# Please enter the commit message for your changes. Lines starting